### PR TITLE
refactored to remove JQuery (#1256)

### DIFF
--- a/app/assets/javascripts/articles.js
+++ b/app/assets/javascripts/articles.js
@@ -1,13 +1,21 @@
 App.articleQueue.onIncoming = function(data) {
-  var alertDiv = $('#floating-alert');
+  var alertDiv = document.querySelector('#floating-alert');
 
-  if (alertDiv.length === 0) {
-    alertDiv = $('<div id="floating-alert" class="alert alert-floating alert-notice">)');
-    $('body').prepend(alertDiv);
+  if (alertDiv === null) {
+    alertDiv = document.createElement('div');
+    alertDiv.setAttribute('id', 'floating-alert');
+    alertDiv.classList.add('alert', 'alert-floating', 'alert-notice');
+    
+    document.body.prepend(alertDiv);
   }
 
   var postPlural = data.length > 1 ? 'posts' : 'post';
-  var closeLink = $('<a class="close">&#10006;</a>').click(function() { alertDiv.remove() });
-
-  alertDiv.html('Psst! Refresh for ' + data.length + ' new ' + postPlural).append(closeLink);
+  
+  var closeLink = document.createElement('a');
+  closeLink.classList.add('close');
+  closeLink.insertAdjacentHTML('afterbegin', '&#10006;');
+  closeLink.addEventListener('click', function() { alertDiv.remove() });
+  
+  alertDiv.insertAdjacentHTML('afterbegin', 'Psst! Refresh for ' + data.length + ' new ' + postPlural);
+  alertDiv.appendChild(closeLink);
 };


### PR DESCRIPTION
* refactored to remove JQuery

* use querySelector and setter methods

- changed querySelectorAll() to querySelector() since there should be only one #floating-alert
- now using setter methods setAttribute(), classList.add(), and insertAdjacentHTML() instead of manipulating object fields directly